### PR TITLE
[ft #157981484] Fetch method to cosume API used to disapprove users' …

### DIFF
--- a/UI/js/admin-panel.js
+++ b/UI/js/admin-panel.js
@@ -164,6 +164,37 @@ const requestDetailsModal = (data, message) => {
         }
       });
   });
+
+   /**
+   * @description fetch method to consume API used to disapprove users' pending requests for logged in admin.
+   *
+   * @param {string} 'allRequestsUrl + data.requestid + /disapprove' - API endpoint
+   * @param {Object} editOptions - Method and headers
+   *
+   * @returns {object} response JSON Object
+   */
+  disapproveBtn.addEventListener('click', () => {
+    const editOptions = {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token,
+      },
+    };
+
+    fetch(`${allRequestsUrl}${data.requestid}/disapprove`, editOptions)
+      .then(response => response.json())
+      .then((disapproveResult) => {
+        if (disapproveResult.success === false) {
+          alert(disapproveResult.message);
+        } else {
+          clearDetailsModal();
+          processModal(disapproveResult);
+          clearTable();
+          fetchAllRequests();
+        }
+      });
+  });
 };
 
 /**


### PR DESCRIPTION
### What does this PR do?
- Review fetch API function to disapprove users' pending requests for a logged-in Admin

### Description of Task to be completed?
- Use the fetch method to consume API for Admin to disapprove users' pending requests in the app.
- Display success message on a modal.

### How should this be manually tested?
- [front-end](https://emeka-m-tracker.herokuapp.com)

### Any background context you want to provide?
- N/A

### What are the relevant pivotal tracker stories?
- [157981484](https://www.pivotaltracker.com/story/show/157981484)

### Screenshots (if appropriate)
- N/A

### Questions:
- N/A